### PR TITLE
Update the API to use exclusively ids as DOM references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,11 @@ When the page is ready, invoke backfeed like so:
   </div>
 </div>
 <script>
-  var $usernameInput = document.getElementById('usernameInput');
-  var $usernameInputStatus = document.getElementById('usernameInputStatus');
-  var $usernameInputGroup = document.getElementById('usernameInputGroup');
   Backfeed.watch({
     username: {
-      'input': $usernameInput,
-      'status': $usernameInputStatus,
-      'group': $usernameInputGroup
+      'input': 'usernameInput',
+      'status': 'usernameInputStatus',
+      'group': 'usernameInputGroup'
     }
     //additional inputs of the same form go here
   });

--- a/backfeed.js
+++ b/backfeed.js
@@ -17,6 +17,9 @@ var Backfeed = (function() {
   
   //Add an event listener to a single form input
   var _registerListener = function(eventName, element, status, group) {
+    element = document.getElementById(element);
+    status = document.getElementById(status);
+    group = document.getElementById(group);
     element.addEventListener(eventName, function invoke(event) {
       _updateStatus(event, status, group);
     }, false);


### PR DESCRIPTION
Resolving [Issue #1](https://github.com/whereswaldon/backfeed/issues/1) by accepting the ids of elements instead of objects.
