### PR TITLE
Simplify API so that only one HTML id is needed per input to be validated.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /html
 /fonts
 /css
+/.babelrc
+/node_modules
+backfeed-compiled*

--- a/README.md
+++ b/README.md
@@ -5,31 +5,39 @@ Simple Bootstrap 3 form validation without JQuery
 
 - Backfeed assumes that you're using the Bootstrap 3 CSS framework.
 - Each input validated must be in its own form-group.
-- Each input validated must have a [glyphicon span for the validation icon](http://getbootstrap.com/css/#forms-control-validation).
-- The input, it's form group, and its glyphicon span must have unique ids.
+- The input must have a unique id.
 
 ##Usage
 
 When the page is ready, invoke backfeed like so:
 
 ```html
-<div id="usernameInputGroup" class="form-group has-feedback">
-  <label for="username" class="control-label sr-only">
-    Username
-  </label>
-  <div class="input-group">
-    <input id="usernameInput" class="form-control" name="username" type="text" maxlength="20" minlength="3" placeholder="johndoe1" required/>
-    <span id="usernameInputStatus" class="glyphicon form-control-feedback" aria-hidden="true"></span>
-  </div>
-</div>
-<script>
-  Backfeed.watch({
-    username: {
-      'input': 'usernameInput',
-      'status': 'usernameInputStatus',
-      'group': 'usernameInputGroup'
-    }
-    //additional inputs of the same form go here
-  });
-</script>
+<body>
+    <div class="container">
+        <div class="form-horizontal">
+            <div class="form-group">
+                <input class="form-control" name="username" id="usernameInput" minlength="4" maxlength="11" required>
+            </div>
+        </div>
+    </div>
+    <script src="../backfeed.js"></script>
+    <script>
+        function ready(fn) {
+            if (document.readyState != 'loading') {
+                fn();
+            } else {
+                document.addEventListener('DOMContentLoaded', fn);
+            }
+        }
+
+        ready(function go() {
+            Backfeed.watch({
+                username: {
+                    'input': 'usernameInput',
+                }
+                //additional inputs of the same form go here
+            });
+        });
+    </script>
+</body>
 ```

--- a/backfeed.js
+++ b/backfeed.js
@@ -13,7 +13,7 @@ var Backfeed = (function() {
   var watchInputs = function(inputList) {
     for (let formInput in inputList) {
       var currInput = inputList[formInput];
-      _registerListener('keyup', currInput['input'], currInput['status']);
+      _registerListener('keyup', currInput['input']);
     }
   };
 
@@ -41,7 +41,7 @@ var Backfeed = (function() {
   };
   
   //Add an event listener to a single form input
-  var _registerListener = function(eventName, element, status) {
+  var _registerListener = function(eventName, element) {
     element = document.getElementById(element);
     var status = _getSiblingFormControlFeedback(element);
     var group = _getParentFormGroup(element);

--- a/backfeed.js
+++ b/backfeed.js
@@ -6,20 +6,45 @@ var Backfeed = (function() {
   const errorGroupClass = 'has-error';
   const successStatusClass = 'glyphicon-ok';
   const successGroupClass = 'has-success';
+  const formGroupClass = 'form-group';
+  const formControlFeedbackClass = 'form-control-feedback';
 
   //attach change listeners to each input
   var watchInputs = function(inputList) {
     for (let formInput in inputList) {
       var currInput = inputList[formInput];
-      _registerListener('keyup', currInput['input'], currInput['status'], currInput['group']);
+      _registerListener('keyup', currInput['input'], currInput['status']);
     }
+  };
+
+  //Traverse upward through the DOM to the nearest form group
+  var _getParentFormGroup = function(element) {
+    while (! element.parentNode.classList.contains(formGroupClass)) {
+      element = element.parentNode;
+    }
+    return element.parentNode;
+  };
+
+  //Traverse input siblings to find sibling form-control-feedback
+  var _getSiblingFormControlFeedback = function(element) {
+    var siblingsInclusive = element.parentNode.children;
+    var sibling;
+    for (var i = 0; i < siblingsInclusive.length; i ++) {
+      sibling = siblingsInclusive[i];
+      if (sibling !== element) {
+        if (sibling.classList.contains(formControlFeedbackClass)) {
+          return sibling;
+        }
+      }
+    }
+    return null;
   };
   
   //Add an event listener to a single form input
-  var _registerListener = function(eventName, element, status, group) {
+  var _registerListener = function(eventName, element, status) {
     element = document.getElementById(element);
-    status = document.getElementById(status);
-    group = document.getElementById(group);
+    var status = _getSiblingFormControlFeedback(element);
+    var group = _getParentFormGroup(element);
     element.addEventListener(eventName, function invoke(event) {
       _updateStatus(event, status, group);
     }, false);

--- a/backfeed.js
+++ b/backfeed.js
@@ -9,6 +9,7 @@ var Backfeed = (function() {
   const formGroupClass = 'form-group';
   const formControlFeedbackClass = 'form-control-feedback';
   const baseStatusClass = 'glyphicon';
+  const baseFeedbackClass = 'has-feedback';
 
   //attach change listeners to each input
   var watchInputs = function(inputList) {
@@ -22,6 +23,14 @@ var Backfeed = (function() {
   var _getParentFormGroup = function(element) {
     while (! element.parentNode.classList.contains(formGroupClass)) {
       element = element.parentNode;
+    }
+    var group = element.parentNode;
+    if (! group.classList.contains(formGroupClass)) {
+      return null; //there is no parent form-group
+    }
+    //ensure that the form-group has the has-feedback class
+    if (! group.classList.contains(baseFeedbackClass)) {
+      group.classList.add(baseFeedbackClass);
     }
     return element.parentNode;
   };

--- a/backfeed.js
+++ b/backfeed.js
@@ -8,6 +8,7 @@ var Backfeed = (function() {
   const successGroupClass = 'has-success';
   const formGroupClass = 'form-group';
   const formControlFeedbackClass = 'form-control-feedback';
+  const baseStatusClass = 'glyphicon';
 
   //attach change listeners to each input
   var watchInputs = function(inputList) {
@@ -32,12 +33,18 @@ var Backfeed = (function() {
     for (var i = 0; i < siblingsInclusive.length; i ++) {
       sibling = siblingsInclusive[i];
       if (sibling !== element) {
+        //if there is a proper sibling, return it
         if (sibling.classList.contains(formControlFeedbackClass)) {
           return sibling;
         }
       }
     }
-    return null;
+    //if no sibling was found, create one and return it.
+    var status = document.createElement('span');
+    status.classList.add(baseStatusClass);
+    status.classList.add(formControlFeedbackClass)
+    element.parentNode.appendChild(status);
+    return status;
   };
   
   //Add an event listener to a single form input


### PR DESCRIPTION
Change the API from needing multiple DOM references (group, status, and input) to just needing the id of the input itself. Now the javascript will find the parent form group for you, and will insert the necessary classes for validation. It will also find or create the sibling feedback span.

This resolves #2.
