### PR TITLE
Update API to accept form id or array of input ids.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,33 @@ Simple Bootstrap 3 form validation without JQuery
 
 - Backfeed assumes that you're using the Bootstrap 3 CSS framework.
 - Each input validated must be in its own form-group.
-- The input must have a unique id.
+- The input must have a unique id (if invoking watchInputs).
+- The form must have a unique id (if invoking watchForm).
 
 ##Usage
 
-When the page is ready, invoke backfeed like so:
+When the page is ready, call Backfeed on your form inputs in one of two ways:
+
+- Backfeed.watchInputs() accepts an array of input ids.
+- Backfeed.watchForm() accepts the id of the parent element of many inputs and activates form feedback on all of them.
 
 ```html
 <body>
     <div class="container">
-        <div class="form-horizontal">
+        <div id="test-form" class="form-horizontal">
             <div class="form-group">
-                <input class="form-control" name="username" id="usernameInput" minlength="4" maxlength="11" required>
+                <input class="form-control" name="username" id="usernameInput" type="text" minlength="4" maxlength="11" required>
+            </div>
+            <div class="form-group">
+                <input class="form-control" name="email" id="emailInput" type="email" minlength="4" maxlength="11" required>
+            </div>
+        </div>
+        <div id="test-form2" class="form-horizontal">
+            <div class="form-group">
+                <input class="form-control" name="password" type="password" minlength="4" maxlength="11" required>
+            </div>
+            <div class="form-group">
+                <input class="form-control" name="confirm" type="password" minlength="4" maxlength="11" required>
             </div>
         </div>
     </div>
@@ -31,12 +46,11 @@ When the page is ready, invoke backfeed like so:
         }
 
         ready(function go() {
-            Backfeed.watch({
-                username: {
-                    'input': 'usernameInput',
-                }
-                //additional inputs of the same form go here
-            });
+            //invoke with array of ids, each corresponding to an input
+            Backfeed.watchInputs(['usernameInput', 'emailInput']);
+            
+            //invoke with id of a form
+            Backfeed.watchForm('test-form2');
         });
     </script>
 </body>

--- a/backfeed.js
+++ b/backfeed.js
@@ -14,8 +14,17 @@ var Backfeed = (function() {
   //attach change listeners to each input
   var watchInputs = function(inputList) {
     for (let formInput in inputList) {
-      var currInput = inputList[formInput];
-      _registerListener('keyup', currInput['input']);
+      var currInput = document.getElementById(inputList[formInput]);
+      _registerListener('keyup', currInput);
+    }
+  };
+
+  //Watch all of the inputs within a form
+  var watchForm = function(formId) {
+    var form = document.getElementById(formId);
+    var inputs = form.querySelectorAll('input');
+    for (var i = 0; i < inputs.length; i++) {
+      _registerListener('keyup', inputs[i]);
     }
   };
 
@@ -58,7 +67,6 @@ var Backfeed = (function() {
   
   //Add an event listener to a single form input
   var _registerListener = function(eventName, element) {
-    element = document.getElementById(element);
     var status = _getSiblingFormControlFeedback(element);
     var group = _getParentFormGroup(element);
     element.addEventListener(eventName, function invoke(event) {
@@ -102,6 +110,7 @@ var Backfeed = (function() {
   };
   
   return {
-    watch: watchInputs
+    watchInputs: watchInputs,
+    watchForm: watchForm
   }
 })();

--- a/backfeed.js
+++ b/backfeed.js
@@ -13,8 +13,8 @@ var Backfeed = (function() {
 
   //attach change listeners to each input
   var watchInputs = function(inputList) {
-    for (let formInput in inputList) {
-      var currInput = document.getElementById(inputList[formInput]);
+    for (var i = 0; i < inputList.length; i++) {
+      var currInput = document.getElementById(inputList[i]);
       _registerListener('keyup', currInput);
     }
   };

--- a/backfeed.js
+++ b/backfeed.js
@@ -11,7 +11,7 @@ var Backfeed = (function() {
   const baseStatusClass = 'glyphicon';
   const baseFeedbackClass = 'has-feedback';
 
-  //attach change listeners to each input
+  //attach change listeners to each input in array
   var watchInputs = function(inputList) {
     for (var i = 0; i < inputList.length; i++) {
       var currInput = document.getElementById(inputList[i]);


### PR DESCRIPTION
Change the API to expose two public methods:

``` javascript
Backfeed.watchInputs(/*array of HTML ids belonging to form inputs*/);
Backfeed.watchForm(/*HTML id of the parent element of many form inputs*/);
```

This makes simple form validation a one-line call.

This resolves #11 
