### PR TITLE
Narrow the input types targeted and change the listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.babelrc
 /node_modules
 backfeed-compiled*
+*.html

--- a/backfeed.js
+++ b/backfeed.js
@@ -24,7 +24,8 @@ var Backfeed = (function() {
     var form = document.getElementById(formId);
     var inputs = form.querySelectorAll('input');
     for (var i = 0; i < inputs.length; i++) {
-      _registerListener('keyup', inputs[i]);
+      //_registerListener('keyup', inputs[i]);
+      _registerListener('input', inputs[i]);
     }
   };
 
@@ -67,6 +68,16 @@ var Backfeed = (function() {
   
   //Add an event listener to a single form input
   var _registerListener = function(eventName, element) {
+    var type = element.getAttribute('type');
+    switch(type) {//don't add listeners to these types
+      case 'submit':
+      case 'button':
+      case 'hidden':
+      case 'reset':
+      case 'radio':
+      case 'checkbox':
+            return;
+    }
     var status = _getSiblingFormControlFeedback(element);
     var group = _getParentFormGroup(element);
     element.addEventListener(eventName, function invoke(event) {


### PR DESCRIPTION
Now doesn't target inputs with the following types:
- submit
- button
- hidden
- reset
- radio
- checkbox

Additionally, this changed the event that the validation listens for to the 'input' event, which catches more kinds of user interaction.
This resolves #15 , #14  , and #13 .
